### PR TITLE
Add caddy executable to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,23 @@ Built according to Heroku's [buildpack API](https://devcenter.heroku.com/article
 
 ## Quick Start
 
-Add the buildpack to your Heroku app:
+Get the `buildpack.tar.gz` download URL from [the latest release](https://github.com/thermondo/heroku-buildpack-caddy/releases/latest).
+It should look something like:
 
-```bash
-heroku buildpacks:add https://github.com/thermondo/heroku-buildpack-caddy/releases/download/v0.0.1/buildpack.tar.gz
+```plaintext
+https://github.com/thermondo/heroku-buildpack-caddy/releases/download/LATEST_VERSION_NUMBER/buildpack.tar.gz
 ```
 
-🚨 _It's highly recommended that you use the **release tarball** URL instead of the GitHub repo URL._
+Then run:
+
+```bash
+heroku buildpacks:add <the-buildpack-url>
+```
 
 Then in your app's [Procfile](https://devcenter.heroku.com/articles/procfile) add something like this:
 
 ```plaintext
-web: ./.caddy/bin/caddy --config <your Caddyfile>
+web: caddy --config <your Caddyfile>
 ```
 
 If you want to run a specific version of Caddy, set the `CADDY_RELEASE` environment variable on your

--- a/bin/compile
+++ b/bin/compile
@@ -97,7 +97,7 @@ EOF
     local profile_dir="${BUILD_DIR}/.profile.d"
     mkdir --parent "${profile_dir}"
     cat <<EOF > "${profile_dir}/caddy.sh"
-export PATH="${bin_dir}:\${PATH}"
+export PATH="\${HOME}/.caddy/bin:\${PATH}"
 EOF
     chmod ugo=rx "${profile_dir}/caddy.sh"
 }

--- a/bin/compile
+++ b/bin/compile
@@ -90,12 +90,16 @@ EOF
     layer_dir="${BUILD_DIR}/.caddy"
     bin_dir="${layer_dir}/bin"
     mkdir --parent "${bin_dir}"
-    (
-        umask ugo=r
-        tar --extract --gzip --to-stdout --file "${download_path}" "caddy" > "${bin_dir}/caddy"
-    )
-    chmod +x "${bin_dir}/caddy"
-    "${bin_dir}/caddy" --version | indent
+    tar --extract --gzip --to-stdout --file "${download_path}" "caddy" > "${bin_dir}/caddy"
+    chmod ugo=rx "${bin_dir}/caddy"
+
+    step "Installing profile.d script"
+    local profile_dir="${BUILD_DIR}/.profile.d"
+    mkdir --parent "${profile_dir}"
+    cat <<EOF > "${profile_dir}/caddy.sh"
+export PATH="${bin_dir}:\${PATH}"
+EOF
+    chmod ugo=rx "${profile_dir}/caddy.sh"
 }
 
 main


### PR DESCRIPTION
* Add `caddy` executable to the `PATH` (inspired by heroku cli buildpack)
* Make README less likely to get outdated on each new release

I think this would be worthy of a 1.0.